### PR TITLE
Use docker-compose to start bash inside the master container

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This section presents how to run a preliminary version of an EDDL training opera
 2. Pull the demonstrator image by running: `docker pull bscppc/compss-deephealth-demo`
 3. Download the docker-compose.yml file provided and store it in a separate directory named **deephealth**: `git clone https://github.com/deephealthproject/docker-compss-runtime`
 4. Run: `docker-compose up -d --scale compss-worker=4`. This will deploy five containers, four of which will take on the role of COMPSs workers, while the remaining will be used as the COMPSs master.
-5. Access the COMPSs master container by running: `docker exec -it deephealth_compss-master_1 bash`. This will open a bash session inside the container, in the directory with the EDDL application and the needed COMPSs configuration options.
+5. Access the COMPSs master container by running: `docker-compose exec compss-master bash`. This will open a bash session inside the container, in the directory with the EDDL application and the needed COMPSs configuration options.
 6. Enter the pyeddl directory: `cd pyeddl/third_party/compss_runtime`
 7. Launch COMPSs by running the following command: `runcompss --lang=python --python_interpreter=python3 --project=linux-based/project.xml --resources=linux-based/resources.xml eddl_train_batch_compss.py`
 8. Once the application finishes correctly, the COMPSs master container can be exited. The containers can be destroyed by running, in the same directory: `docker-compose down -v`


### PR DESCRIPTION
Hi,

On my Ubuntu LTS, following the `README.md` instructions (really helpful! Thanks!) I got almost everything working without having to change the commands.

The exception was how to run `bash` in the master container. The command suggested in the `README.md` appears to be platform and/or version dependent. On my local environment it the container has a different name, so it fails to run `bash`.

```bash
kinow@ranma:/tmp/docker-compss-runtime$ docker exec -it deephealth_compss-master_1 bash
Error: No such container: deephealth_compss-master_1
```

This PR uses the `docker-compose` command, where we can use the service name.

```bash
docker-compose exec compss-master bash
```